### PR TITLE
Specify specific architectures in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino Library for the Atmel/Microchip ECC508 and ECC608 crypto chips
 paragraph=
 category=Communication
 url=https://github.com/arduino-libraries/ArduinoECCX08
-architectures=*
+architectures=samd,megaavr
 includes=ArduinoECCX08.h


### PR DESCRIPTION
Based on #3 and #4, this library cannot work with the AVR architecture, so I've updated the `library.properties` file to be more specific. Just SAMD and megaAVR for now.

@facchinm let me know what you think of this approach ...