### PR TITLE
Added self signed certificate create capabilities

### DIFF
--- a/examples/Tools/ECCX08SelfSignedCert/ECCX08SelfSignedCert.ino
+++ b/examples/Tools/ECCX08SelfSignedCert/ECCX08SelfSignedCert.ino
@@ -100,6 +100,10 @@ void setup() {
   Serial.println("Here's your self signed cert, enjoy!");
   Serial.println();
   Serial.println(cert);
+  Serial.println();
+
+  Serial.print("SHA1: ");
+  Serial.println(ECCX08SelfSignedCert.sha1());
 }
 
 void loop() {

--- a/examples/Tools/ECCX08SelfSignedCert/ECCX08SelfSignedCert.ino
+++ b/examples/Tools/ECCX08SelfSignedCert/ECCX08SelfSignedCert.ino
@@ -1,0 +1,145 @@
+/*
+  ArduinoECCX08 - Self Signed Cert
+
+  This sketch can be used to generate a self signed certificate
+  for a private key generated in an ECC508/ECC608 crypto chip slot.
+  The issue and expired date, and signature are stored in another
+  slot for reconstrution.
+
+  If the ECC508/ECC608 is not configured and locked it prompts
+  the user to configure and lock the chip with a default TLS
+  configuration.
+
+  The user can also select the slot number to use for the private key
+  and storage.
+  A new private key can also be generated in this slot.
+
+  The circuit:
+  - Arduino MKR board equipped with ECC508 or ECC608 chip
+
+  This example code is in the public domain.
+*/
+
+#include <ArduinoECCX08.h>
+#include <utility/ECCX08SelfSignedCert.h>
+#include <utility/ECCX08DefaultTLSConfig.h>
+
+void setup() {
+  Serial.begin(9600);
+  while (!Serial);
+
+  if (!ECCX08.begin()) {
+    Serial.println("No ECCX08 present!");
+    while (1);
+  }
+
+  String serialNumber = ECCX08.serialNumber();
+
+  Serial.print("ECCX08 Serial Number = ");
+  Serial.println(serialNumber);
+  Serial.println();
+
+  if (!ECCX08.locked()) {
+    String lock = promptAndReadLine("The ECCX08 on your board is not locked, would you like to PERMANENTLY configure and lock it now? (y/N)", "N");
+    lock.toLowerCase();
+
+    if (!lock.startsWith("y")) {
+      Serial.println("Unfortunately you can't proceed without locking it :(");
+      while (1);
+    }
+
+    if (!ECCX08.writeConfiguration(ECCX08_DEFAULT_TLS_CONFIG)) {
+      Serial.println("Writing ECCX08 configuration failed!");
+      while (1);
+    }
+
+    if (!ECCX08.lock()) {
+      Serial.println("Locking ECCX08 configuration failed!");
+      while (1);
+    }
+
+    Serial.println("ECCX08 locked successfully");
+    Serial.println();
+  }
+
+  Serial.println("Hi there, in order to generate a new self signed cert for your board, we'll need the following information ...");
+  Serial.println();
+
+  String issueYear          = promptAndReadLine("Please enter the issue year of the certificate? (2000 - 2031)", "2019");
+  String issueMonth         = promptAndReadLine("Please enter the issue month of the certificate? (1 - 12)", "1");
+  String issueDay           = promptAndReadLine("Please enter the issue day of the certificate? (1 - 31)", "1");
+  String issueHour          = promptAndReadLine("Please enter the issue hour of the certificate? (0 - 23)", "0");
+  String expireYears        = promptAndReadLine("Please enter how many years the certificate is valid for? (1 - 31)", "31");
+  String privateKeySlot     = promptAndReadLine("What slot would you like to use for the private key? (0 - 4)", "0");
+  String storageSlot        = promptAndReadLine("What slot would you like to use for storage? (8 - 15)", "8");
+  String generateNewKey     = promptAndReadLine("Would you like to generate a new private key? (Y/n)", "Y");
+
+  Serial.println();
+
+  generateNewKey.toLowerCase();
+
+  if (!ECCX08SelfSignedCert.beginStorage(privateKeySlot.toInt(), storageSlot.toInt(), generateNewKey.startsWith("y"))) {
+    Serial.println("Error starting self signed cert generation!");
+    while (1);
+  }
+
+  ECCX08SelfSignedCert.setCommonName(ECCX08.serialNumber());
+  ECCX08SelfSignedCert.setIssueYear(issueYear.toInt());
+  ECCX08SelfSignedCert.setIssueMonth(issueMonth.toInt());
+  ECCX08SelfSignedCert.setIssueDay(issueDay.toInt());
+  ECCX08SelfSignedCert.setIssueHour(issueHour.toInt());
+  ECCX08SelfSignedCert.setExpireYears(expireYears.toInt());
+
+  String cert = ECCX08SelfSignedCert.endStorage();
+
+  if (!cert) {
+    Serial.println("Error generating self signed cert!");
+    while (1);
+  }
+
+  Serial.println("Here's your self signed cert, enjoy!");
+  Serial.println();
+  Serial.println(cert);
+}
+
+void loop() {
+  // do nothing
+}
+
+String promptAndReadLine(const char* prompt, const char* defaultValue) {
+  Serial.print(prompt);
+  Serial.print(" [");
+  Serial.print(defaultValue);
+  Serial.print("]: ");
+
+  String s = readLine();
+
+  if (s.length() == 0) {
+    s = defaultValue;
+  }
+
+  Serial.println(s);
+
+  return s;
+}
+
+String readLine() {
+  String line;
+
+  while (1) {
+    if (Serial.available()) {
+      char c = Serial.read();
+
+      if (c == '\r') {
+        // ignore
+        continue;
+      } else if (c == '\n') {
+        break;
+      }
+
+      line += c;
+    }
+  }
+
+  return line;
+}

--- a/src/ECCX08.cpp
+++ b/src/ECCX08.cpp
@@ -61,20 +61,29 @@ void ECCX08Class::end()
 #endif
 }
 
+int ECCX08Class::serialNumber(byte sn[])
+{
+  if (!read(0, 0, &sn[0], 4)) {
+    return 0;
+  }
+
+  if (!read(0, 2, &sn[4], 4)) {
+    return 0;
+  }
+
+  if (!read(0, 3, &sn[8], 4)) {
+    return 0;
+  }
+
+  return 1;
+}
+
 String ECCX08Class::serialNumber()
 {
   String result = (char*)NULL;
   byte sn[12];
 
-  if (!read(0, 0, &sn[0], 4)) {
-    return result;
-  }
-
-  if (!read(0, 2, &sn[4], 4)) {
-    return result;
-  }
-
-  if (!read(0, 3, &sn[8], 4)) {
+  if (!serialNumber(sn)) {
     return result;
   }
 

--- a/src/ECCX08.h
+++ b/src/ECCX08.h
@@ -32,6 +32,7 @@ public:
   int begin();
   void end();
 
+  int serialNumber(byte sn[]);
   String serialNumber();
 
   long random(long max);

--- a/src/utility/ASN1Utils.cpp
+++ b/src/utility/ASN1Utils.cpp
@@ -1,0 +1,349 @@
+/*
+  This file is part of the ArduinoECCX08 library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "ASN1Utils.h"
+
+int ASN1UtilsClass::versionLength()
+{
+  return 3;
+}
+
+int ASN1UtilsClass::subjectLength(const String& countryName,
+                                  const String& stateProvinceName,
+                                  const String& localityName,
+                                  const String& organizationName,
+                                  const String& organizationalUnitName,
+                                  const String& commonName)
+{
+  int length                       = 0;
+  int countryNameLength            = countryName.length();
+  int stateProvinceNameLength      = stateProvinceName.length();
+  int localityNameLength           = localityName.length();
+  int organizationNameLength       = organizationName.length();
+  int organizationalUnitNameLength = organizationalUnitName.length();
+  int commonNameLength             = commonName.length();
+
+  if (countryNameLength) {
+    length += (11 + countryNameLength);
+  }
+
+  if (stateProvinceNameLength) {
+    length += (11 + stateProvinceNameLength);
+  }
+
+  if (localityNameLength) {
+    length += (11 + localityNameLength);
+  }
+
+  if (organizationNameLength) {
+    length += (11 + organizationNameLength);
+  }
+
+  if (organizationalUnitNameLength) {
+    length += (11 + organizationalUnitNameLength);
+  }
+
+  if (commonNameLength) {
+    length += (11 + commonNameLength);
+  }
+
+  return length;
+}
+
+int ASN1UtilsClass::publicKeyLength()
+{
+  return (2 + 2 + 9 + 10 + 4 + 64);
+}
+
+int ASN1UtilsClass::signatureLength(const byte signature[])
+{
+  const byte* r = &signature[0];
+  const byte* s = &signature[32];
+
+  int rLength = 32;
+  int sLength = 32;
+
+  while (*r == 0x00 && rLength) {
+    r++;
+    rLength--;
+  }
+
+  if (*r & 0x80) {
+    rLength++;
+  }
+
+  while (*s == 0x00 && sLength) {
+    s++;
+    sLength--;
+  }
+
+  if (*s & 0x80) {
+    sLength++;
+  }
+
+  return (21 + rLength + sLength);
+}
+
+int ASN1UtilsClass::sequenceHeaderLength(int length)
+{
+  if (length > 255) {
+    return 4;
+  } else if (length > 127) {
+    return 3;
+  } else {
+    return 2;
+  }
+}
+
+void ASN1UtilsClass::appendVersion(int version, byte out[])
+{
+  out[0] = ASN1_INTEGER;
+  out[1] = 0x01;
+  out[2] = version;
+}
+
+void ASN1UtilsClass::appendSubject(const String& countryName,
+                                    const String& stateProvinceName,
+                                    const String& localityName,
+                                    const String& organizationName,
+                                    const String& organizationalUnitName,
+                                    const String& commonName,
+                                    byte out[])
+{
+  if (countryName.length() > 0) {
+    out += appendName(countryName, 0x06, out);
+  }
+
+  if (stateProvinceName.length() > 0) {
+    out += appendName(stateProvinceName, 0x08, out);
+  }
+
+  if (localityName.length() > 0) {
+    out += appendName(localityName, 0x07, out);
+  }
+
+  if (organizationName.length() > 0) {
+    out += appendName(organizationName, 0x0a, out);
+  }
+
+  if (organizationalUnitName.length() > 0) {
+    out += appendName(organizationalUnitName, 0x0b, out);
+  }
+
+  if (commonName.length() > 0) {
+    out += appendName(commonName, 0x03, out);
+  }
+}
+
+void ASN1UtilsClass::appendPublicKey(const byte publicKey[], byte out[])
+{
+  int subjectPublicKeyDataLength = 2 + 9 + 10 + 4 + 64;
+
+  // subject public key
+  *out++ = ASN1_SEQUENCE;
+  *out++ = (subjectPublicKeyDataLength) & 0xff;
+
+  *out++ = ASN1_SEQUENCE;
+  *out++ = 0x13;
+
+  // EC public key
+  *out++ = ASN1_OBJECT_IDENTIFIER;
+  *out++ = 0x07;
+  *out++ = 0x2a;
+  *out++ = 0x86;
+  *out++ = 0x48;
+  *out++ = 0xce;
+  *out++ = 0x3d;
+  *out++ = 0x02;
+  *out++ = 0x01;
+
+  // PRIME 256 v1
+  *out++ = ASN1_OBJECT_IDENTIFIER;
+  *out++ = 0x08;
+  *out++ = 0x2a;
+  *out++ = 0x86;
+  *out++ = 0x48;
+  *out++ = 0xce;
+  *out++ = 0x3d;
+  *out++ = 0x03;
+  *out++ = 0x01;
+  *out++ = 0x07;
+
+  *out++ = 0x03;
+  *out++ = 0x42;
+  *out++ = 0x00;
+  *out++ = 0x04;
+
+  memcpy(out, publicKey, 64);
+}
+
+void ASN1UtilsClass::appendSignature(const byte signature[], byte out[])
+{
+  // signature algorithm
+  *out++ = ASN1_SEQUENCE;
+  *out++ = 0x0a;
+  *out++ = ASN1_OBJECT_IDENTIFIER;
+  *out++ = 0x08;
+
+  // ECDSA with SHA256
+  *out++ = 0x2a;
+  *out++ = 0x86;
+  *out++ = 0x48;
+  *out++ = 0xce;
+  *out++ = 0x3d;
+  *out++ = 0x04;
+  *out++ = 0x03;
+  *out++ = 0x02;
+
+  const byte* r = &signature[0];
+  const byte* s = &signature[32];
+
+  int rLength = 32;
+  int sLength = 32;
+
+  while (*r == 0 && rLength) {
+    r++;
+    rLength--;
+  }
+
+  while (*s == 0 && sLength) {
+    s++;
+    sLength--;
+  }
+
+  if (*r & 0x80) {
+    rLength++;  
+  }
+
+  if (*s & 0x80) {
+    sLength++;
+  }
+
+  *out++ = ASN1_BIT_STRING;
+  *out++ = (rLength + sLength + 7);
+  *out++ = 0;
+
+  *out++ = ASN1_SEQUENCE;
+  *out++ = (rLength + sLength + 4);
+
+  *out++ = ASN1_INTEGER;
+  *out++ = rLength;
+  if ((*r & 0x80) && rLength) {
+    *out++ = 0;
+    rLength--;
+  }
+  memcpy(out, r, rLength);
+  out += rLength;
+
+  *out++ = ASN1_INTEGER;
+  *out++ = sLength;
+  if ((*s & 0x80) && sLength) {
+    *out++ = 0;
+    sLength--;
+  }
+  memcpy(out, s, sLength);
+  out += rLength;
+}
+
+int ASN1UtilsClass::appendName(const String& name, int type, byte out[])
+{
+  int nameLength = name.length();
+
+  *out++ = ASN1_SET;
+  *out++ = nameLength + 9;
+
+  *out++ = ASN1_SEQUENCE;
+  *out++ = nameLength + 7;
+
+  *out++ = ASN1_OBJECT_IDENTIFIER;
+  *out++ = 0x03;
+  *out++ = 0x55;
+  *out++ = 0x04;
+  *out++ = type;
+
+  *out++ = ASN1_PRINTABLE_STRING;
+  *out++ = nameLength;
+  memcpy(out, name.c_str(), nameLength);
+
+  return (nameLength + 11);
+}
+
+void ASN1UtilsClass::appendSequenceHeader(int length, byte out[])
+{
+  *out++ = ASN1_SEQUENCE;
+  if (length > 255) {
+    *out++ = 0x82;
+    *out++ = (length >> 8) & 0xff;
+  } else if (length > 127) {
+    *out++ = 0x81;
+  }
+  *out++ = (length) & 0xff;
+}
+
+
+String ASN1UtilsClass::base64Encode(const byte in[], unsigned int length, const char* prefix, const char* suffix)
+{
+  static const char* CODES = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+  int b;
+  String out;
+
+  int reserveLength = 4 * ((length + 2) / 3) + ((length / 3 * 4) / 76) + strlen(prefix) + strlen(suffix);
+  out.reserve(reserveLength);
+
+  if (prefix) {
+    out += prefix;
+  }
+  
+  for (unsigned int i = 0; i < length; i += 3) {
+    if (i > 0 && (i / 3 * 4) % 76 == 0) { 
+      out += '\n'; 
+    }
+
+    b = (in[i] & 0xFC) >> 2;
+    out += CODES[b];
+
+    b = (in[i] & 0x03) << 4;
+    if (i + 1 < length) {
+      b |= (in[i + 1] & 0xF0) >> 4;
+      out += CODES[b];
+      b = (in[i + 1] & 0x0F) << 2;
+      if (i + 2 < length) {
+         b |= (in[i + 2] & 0xC0) >> 6;
+         out += CODES[b];
+         b = in[i + 2] & 0x3F;
+         out += CODES[b];
+      } else {
+        out += CODES[b];
+        out += '=';
+      }
+    } else {
+      out += CODES[b];
+      out += "==";
+    }
+  }
+
+  if (suffix) {
+    out += suffix;
+  }
+
+  return out;
+}
+
+ASN1UtilsClass ASN1Utils;

--- a/src/utility/ASN1Utils.h
+++ b/src/utility/ASN1Utils.h
@@ -34,7 +34,7 @@ class ASN1UtilsClass {
 public:
   int versionLength();
 
-  int subjectLength(const String& countryName,
+  int issuerOrSubjectLength(const String& countryName,
                     const String& stateProvinceName,
                     const String& localityName,
                     const String& organizationName,
@@ -45,25 +45,33 @@ public:
 
   int signatureLength(const byte signature[]);
 
+  int serialNumberLength(const byte serialNumber[], int length);
+
   int sequenceHeaderLength(int length);
 
   void appendVersion(int version, byte out[]);
 
-  void appendSubject(const String& countryName,
-                     const String& stateProvinceName,
-                     const String& localityName,
-                     const String& organizationName,
-                     const String& organizationalUnitName,
-                     const String& commonName,
-                     byte out[]);
+  void appendIssuerOrSubject(const String& countryName,
+                             const String& stateProvinceName,
+                             const String& localityName,
+                             const String& organizationName,
+                             const String& organizationalUnitName,
+                             const String& commonName,
+                             byte out[]);
 
    void appendPublicKey(const byte publicKey[], byte out[]);
 
    void appendSignature(const byte signature[], byte out[]);
 
+   void appendSerialNumber(const byte serialNumber[], int length, byte out[]);
+
    int appendName(const String& name, int type, byte out[]);
 
    void appendSequenceHeader(int length, byte out[]);
+
+   int appendDate(int year, int month, int day, int hour, int minute, int second, byte out[]);
+
+   int appendEcdsaWithSHA256(byte out[]);
 
    String base64Encode(const byte in[], unsigned int length, const char* prefix, const char* suffix);
 };

--- a/src/utility/ASN1Utils.h
+++ b/src/utility/ASN1Utils.h
@@ -1,0 +1,73 @@
+/*
+  This file is part of the ArduinoECCX08 library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _ASN1_UTILS_H_
+#define _ASN1_UTILS_H_
+
+#include <Arduino.h>
+
+#define ASN1_INTEGER           0x02
+#define ASN1_BIT_STRING        0x03
+#define ASN1_NULL              0x05
+#define ASN1_OBJECT_IDENTIFIER 0x06
+#define ASN1_PRINTABLE_STRING  0x13
+#define ASN1_SEQUENCE          0x30
+#define ASN1_SET               0x31
+
+class ASN1UtilsClass {
+public:
+  int versionLength();
+
+  int subjectLength(const String& countryName,
+                    const String& stateProvinceName,
+                    const String& localityName,
+                    const String& organizationName,
+                    const String& organizationalUnitName,
+                    const String& commonName);
+
+  int publicKeyLength();
+
+  int signatureLength(const byte signature[]);
+
+  int sequenceHeaderLength(int length);
+
+  void appendVersion(int version, byte out[]);
+
+  void appendSubject(const String& countryName,
+                     const String& stateProvinceName,
+                     const String& localityName,
+                     const String& organizationName,
+                     const String& organizationalUnitName,
+                     const String& commonName,
+                     byte out[]);
+
+   void appendPublicKey(const byte publicKey[], byte out[]);
+
+   void appendSignature(const byte signature[], byte out[]);
+
+   int appendName(const String& name, int type, byte out[]);
+
+   void appendSequenceHeader(int length, byte out[]);
+
+   String base64Encode(const byte in[], unsigned int length, const char* prefix, const char* suffix);
+};
+
+extern ASN1UtilsClass ASN1Utils;
+
+#endif

--- a/src/utility/ASN1Utils.h
+++ b/src/utility/ASN1Utils.h
@@ -59,21 +59,19 @@ public:
                              const String& commonName,
                              byte out[]);
 
-   void appendPublicKey(const byte publicKey[], byte out[]);
+   int appendPublicKey(const byte publicKey[], byte out[]);
 
-   void appendSignature(const byte signature[], byte out[]);
+   int appendSignature(const byte signature[], byte out[]);
 
-   void appendSerialNumber(const byte serialNumber[], int length, byte out[]);
+   int appendSerialNumber(const byte serialNumber[], int length, byte out[]);
 
    int appendName(const String& name, int type, byte out[]);
 
-   void appendSequenceHeader(int length, byte out[]);
+   int appendSequenceHeader(int length, byte out[]);
 
    int appendDate(int year, int month, int day, int hour, int minute, int second, byte out[]);
 
    int appendEcdsaWithSHA256(byte out[]);
-
-   String base64Encode(const byte in[], unsigned int length, const char* prefix, const char* suffix);
 };
 
 extern ASN1UtilsClass ASN1Utils;

--- a/src/utility/ECCX08CSR.cpp
+++ b/src/utility/ECCX08CSR.cpp
@@ -20,6 +20,7 @@
 #include "ArduinoECCX08.h"
 
 #include "ASN1Utils.h"
+#include "PEMUtils.h"
 
 #include "ECCX08CSR.h"
 
@@ -139,7 +140,7 @@ String ECCX08CSRClass::end()
   ASN1Utils.appendSignature(signature, out);
   out += signatureLen;
 
-  return ASN1Utils.base64Encode(csr, csrLen + csrHeaderLen, "-----BEGIN CERTIFICATE REQUEST-----\n", "\n-----END CERTIFICATE REQUEST-----\n");
+  return PEMUtils.base64Encode(csr, csrLen + csrHeaderLen, "-----BEGIN CERTIFICATE REQUEST-----\n", "\n-----END CERTIFICATE REQUEST-----\n");
 }
 
 void ECCX08CSRClass::setCountryName(const char *countryName)

--- a/src/utility/ECCX08CSR.cpp
+++ b/src/utility/ECCX08CSR.cpp
@@ -51,12 +51,12 @@ int ECCX08CSRClass::begin(int slot, bool newPrivateKey)
 String ECCX08CSRClass::end()
 {
   int versionLen = ASN1Utils.versionLength();
-  int subjectLen = ASN1Utils.subjectLength(_countryName,
-                                            _stateProvinceName,
-                                            _localityName,
-                                            _organizationName,
-                                            _organizationalUnitName,
-                                            _commonName);
+  int subjectLen = ASN1Utils.issuerOrSubjectLength(_countryName,
+                                                    _stateProvinceName,
+                                                    _localityName,
+                                                    _organizationName,
+                                                    _organizationalUnitName,
+                                                    _commonName);
   int subjectHeaderLen = ASN1Utils.sequenceHeaderLength(subjectLen);
   int publicKeyLen = ASN1Utils.publicKeyLength();
 
@@ -76,12 +76,12 @@ String ECCX08CSRClass::end()
   // subject
   ASN1Utils.appendSequenceHeader(subjectLen, out);
   out += subjectHeaderLen;
-  ASN1Utils.appendSubject(_countryName,
-                _stateProvinceName,
-                _localityName,
-                _organizationName,
-                _organizationalUnitName,
-                _commonName, out);
+  ASN1Utils.appendIssuerOrSubject(_countryName,
+                                  _stateProvinceName,
+                                  _localityName,
+                                  _organizationName,
+                                  _organizationalUnitName,
+                                  _commonName, out);
   out += subjectLen;
 
   // public key

--- a/src/utility/ECCX08CSR.cpp
+++ b/src/utility/ECCX08CSR.cpp
@@ -19,56 +19,9 @@
 
 #include "ArduinoECCX08.h"
 
+#include "ASN1Utils.h"
+
 #include "ECCX08CSR.h"
-
-static String base64Encode(const byte in[], unsigned int length, const char* prefix, const char* suffix)
-{
-  static const char* CODES = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-
-  int b;
-  String out;
-
-  int reserveLength = 4 * ((length + 2) / 3) + ((length / 3 * 4) / 76) + strlen(prefix) + strlen(suffix);
-  out.reserve(reserveLength);
-
-  if (prefix) {
-    out += prefix;
-  }
-  
-  for (unsigned int i = 0; i < length; i += 3) {
-    if (i > 0 && (i / 3 * 4) % 76 == 0) { 
-      out += '\n'; 
-    }
-
-    b = (in[i] & 0xFC) >> 2;
-    out += CODES[b];
-
-    b = (in[i] & 0x03) << 4;
-    if (i + 1 < length) {
-      b |= (in[i + 1] & 0xF0) >> 4;
-      out += CODES[b];
-      b = (in[i + 1] & 0x0F) << 2;
-      if (i + 2 < length) {
-         b |= (in[i + 2] & 0xC0) >> 6;
-         out += CODES[b];
-         b = in[i + 2] & 0x3F;
-         out += CODES[b];
-      } else {
-        out += CODES[b];
-        out += '=';
-      }
-    } else {
-      out += CODES[b];
-      out += "==";
-    }
-  }
-
-  if (suffix) {
-    out += suffix;
-  }
-
-  return out;
-}
 
 ECCX08CSRClass::ECCX08CSRClass()
 {
@@ -77,14 +30,6 @@ ECCX08CSRClass::ECCX08CSRClass()
 ECCX08CSRClass::~ECCX08CSRClass()
 {
 }
-
-#define ASN1_INTEGER           0x02
-#define ASN1_BIT_STRING        0x03
-#define ASN1_NULL              0x05
-#define ASN1_OBJECT_IDENTIFIER 0x06
-#define ASN1_PRINTABLE_STRING  0x13
-#define ASN1_SEQUENCE          0x30
-#define ASN1_SET               0x31
 
 int ECCX08CSRClass::begin(int slot, bool newPrivateKey)
 {
@@ -105,33 +50,33 @@ int ECCX08CSRClass::begin(int slot, bool newPrivateKey)
 
 String ECCX08CSRClass::end()
 {
-  int versionLen = versionLength();
-  int subjectLen = subjectLength(_countryName,
-                                  _stateProvinceName,
-                                  _localityName,
-                                  _organizationName,
-                                  _organizationalUnitName,
-                                  _commonName);
-  int subjectHeaderLen = sequenceHeaderLength(subjectLen);
-  int publicKeyLen = publicKeyLength();
+  int versionLen = ASN1Utils.versionLength();
+  int subjectLen = ASN1Utils.subjectLength(_countryName,
+                                            _stateProvinceName,
+                                            _localityName,
+                                            _organizationName,
+                                            _organizationalUnitName,
+                                            _commonName);
+  int subjectHeaderLen = ASN1Utils.sequenceHeaderLength(subjectLen);
+  int publicKeyLen = ASN1Utils.publicKeyLength();
 
   int csrInfoLen = versionLen + subjectHeaderLen + subjectLen + publicKeyLen + 2;
-  int csrInfoHeaderLen = sequenceHeaderLength(csrInfoLen);
+  int csrInfoHeaderLen = ASN1Utils.sequenceHeaderLength(csrInfoLen);
 
   byte csrInfo[csrInfoHeaderLen + csrInfoLen];
   byte* out = csrInfo;
 
-  appendSequenceHeader(csrInfoLen, out);
+  ASN1Utils.appendSequenceHeader(csrInfoLen, out);
   out += csrInfoHeaderLen;
 
   // version
-  appendVersion(0x00, out);
+  ASN1Utils.appendVersion(0x00, out);
   out += versionLen;
 
   // subject
-  appendSequenceHeader(subjectLen, out);
+  ASN1Utils.appendSequenceHeader(subjectLen, out);
   out += subjectHeaderLen;
-  appendSubject(_countryName,
+  ASN1Utils.appendSubject(_countryName,
                 _stateProvinceName,
                 _localityName,
                 _organizationName,
@@ -140,7 +85,7 @@ String ECCX08CSRClass::end()
   out += subjectLen;
 
   // public key
-  appendPublicKey(_publicKey, out);
+  ASN1Utils.appendPublicKey(_publicKey, out);
   out += publicKeyLen;
 
   // terminator
@@ -176,14 +121,14 @@ String ECCX08CSRClass::end()
     return "";
   }
 
-  int signatureLen = signatureLength(signature);
+  int signatureLen = ASN1Utils.signatureLength(signature);
   int csrLen = csrInfoHeaderLen + csrInfoLen + signatureLen;
-  int csrHeaderLen = sequenceHeaderLength(csrLen);
+  int csrHeaderLen = ASN1Utils.sequenceHeaderLength(csrLen);
 
   byte csr[csrLen + csrHeaderLen];
   out = csr;
 
-  appendSequenceHeader(csrLen, out);
+  ASN1Utils.appendSequenceHeader(csrLen, out);
   out += csrHeaderLen;
 
   // info
@@ -191,10 +136,10 @@ String ECCX08CSRClass::end()
   out += (csrInfoHeaderLen + csrInfoLen);
 
   // signature
-  appendSignature(signature, out);
+  ASN1Utils.appendSignature(signature, out);
   out += signatureLen;
 
-  return base64Encode(csr, csrLen + csrHeaderLen, "-----BEGIN CERTIFICATE REQUEST-----\n", "\n-----END CERTIFICATE REQUEST-----\n");
+  return ASN1Utils.base64Encode(csr, csrLen + csrHeaderLen, "-----BEGIN CERTIFICATE REQUEST-----\n", "\n-----END CERTIFICATE REQUEST-----\n");
 }
 
 void ECCX08CSRClass::setCountryName(const char *countryName)
@@ -227,281 +172,5 @@ void ECCX08CSRClass::setCommonName(const char* commonName)
   _commonName = commonName;
 }
 
-int ECCX08CSRClass::versionLength()
-{
-  return 3;
-}
-
-int ECCX08CSRClass::subjectLength(const String& countryName,
-                                  const String& stateProvinceName,
-                                  const String& localityName,
-                                  const String& organizationName,
-                                  const String& organizationalUnitName,
-                                  const String& commonName)
-{
-  int length                       = 0;
-  int countryNameLength            = countryName.length();
-  int stateProvinceNameLength      = stateProvinceName.length();
-  int localityNameLength           = localityName.length();
-  int organizationNameLength       = organizationName.length();
-  int organizationalUnitNameLength = organizationalUnitName.length();
-  int commonNameLength             = commonName.length();
-
-  if (countryNameLength) {
-    length += (11 + countryNameLength);
-  }
-
-  if (stateProvinceNameLength) {
-    length += (11 + stateProvinceNameLength);
-  }
-
-  if (localityNameLength) {
-    length += (11 + localityNameLength);
-  }
-
-  if (organizationNameLength) {
-    length += (11 + organizationNameLength);
-  }
-
-  if (organizationalUnitNameLength) {
-    length += (11 + organizationalUnitNameLength);
-  }
-
-  if (commonNameLength) {
-    length += (11 + commonNameLength);
-  }
-
-  return length;
-}
-
-int ECCX08CSRClass::publicKeyLength()
-{
-  return (2 + 2 + 9 + 10 + 4 + 64);
-}
-
-int ECCX08CSRClass::signatureLength(const byte signature[])
-{
-  const byte* r = &signature[0];
-  const byte* s = &signature[32];
-
-  int rLength = 32;
-  int sLength = 32;
-
-  while (*r == 0x00 && rLength) {
-    r++;
-    rLength--;
-  }
-
-  if (*r & 0x80) {
-    rLength++;
-  }
-
-  while (*s == 0x00 && sLength) {
-    s++;
-    sLength--;
-  }
-
-  if (*s & 0x80) {
-    sLength++;
-  }
-
-  return (21 + rLength + sLength);
-}
-
-int ECCX08CSRClass::sequenceHeaderLength(int length)
-{
-  if (length > 255) {
-    return 4;
-  } else if (length > 127) {
-    return 3;
-  } else {
-    return 2;
-  }
-}
-
-void ECCX08CSRClass::appendVersion(int version, byte out[])
-{
-  out[0] = ASN1_INTEGER;
-  out[1] = 0x01;
-  out[2] = version;
-}
-
-void ECCX08CSRClass::appendSubject(const String& countryName,
-                                    const String& stateProvinceName,
-                                    const String& localityName,
-                                    const String& organizationName,
-                                    const String& organizationalUnitName,
-                                    const String& commonName,
-                                    byte out[])
-{
-  if (countryName.length() > 0) {
-    out += appendName(countryName, 0x06, out);
-  }
-
-  if (stateProvinceName.length() > 0) {
-    out += appendName(stateProvinceName, 0x08, out);
-  }
-
-  if (localityName.length() > 0) {
-    out += appendName(localityName, 0x07, out);
-  }
-
-  if (organizationName.length() > 0) {
-    out += appendName(organizationName, 0x0a, out);
-  }
-
-  if (organizationalUnitName.length() > 0) {
-    out += appendName(organizationalUnitName, 0x0b, out);
-  }
-
-  if (commonName.length() > 0) {
-    out += appendName(commonName, 0x03, out);
-  }
-}
-
-void ECCX08CSRClass::appendPublicKey(const byte publicKey[], byte out[])
-{
-  int subjectPublicKeyDataLength = 2 + 9 + 10 + 4 + 64;
-
-  // subject public key
-  *out++ = ASN1_SEQUENCE;
-  *out++ = (subjectPublicKeyDataLength) & 0xff;
-
-  *out++ = ASN1_SEQUENCE;
-  *out++ = 0x13;
-
-  // EC public key
-  *out++ = ASN1_OBJECT_IDENTIFIER;
-  *out++ = 0x07;
-  *out++ = 0x2a;
-  *out++ = 0x86;
-  *out++ = 0x48;
-  *out++ = 0xce;
-  *out++ = 0x3d;
-  *out++ = 0x02;
-  *out++ = 0x01;
-
-  // PRIME 256 v1
-  *out++ = ASN1_OBJECT_IDENTIFIER;
-  *out++ = 0x08;
-  *out++ = 0x2a;
-  *out++ = 0x86;
-  *out++ = 0x48;
-  *out++ = 0xce;
-  *out++ = 0x3d;
-  *out++ = 0x03;
-  *out++ = 0x01;
-  *out++ = 0x07;
-
-  *out++ = 0x03;
-  *out++ = 0x42;
-  *out++ = 0x00;
-  *out++ = 0x04;
-
-  memcpy(out, publicKey, 64);
-}
-
-void ECCX08CSRClass::appendSignature(const byte signature[], byte out[])
-{
-  // signature algorithm
-  *out++ = ASN1_SEQUENCE;
-  *out++ = 0x0a;
-  *out++ = ASN1_OBJECT_IDENTIFIER;
-  *out++ = 0x08;
-
-  // ECDSA with SHA256
-  *out++ = 0x2a;
-  *out++ = 0x86;
-  *out++ = 0x48;
-  *out++ = 0xce;
-  *out++ = 0x3d;
-  *out++ = 0x04;
-  *out++ = 0x03;
-  *out++ = 0x02;
-
-  const byte* r = &signature[0];
-  const byte* s = &signature[32];
-
-  int rLength = 32;
-  int sLength = 32;
-
-  while (*r == 0 && rLength) {
-    r++;
-    rLength--;
-  }
-
-  while (*s == 0 && sLength) {
-    s++;
-    sLength--;
-  }
-
-  if (*r & 0x80) {
-    rLength++;  
-  }
-
-  if (*s & 0x80) {
-    sLength++;
-  }
-
-  *out++ = ASN1_BIT_STRING;
-  *out++ = (rLength + sLength + 7);
-  *out++ = 0;
-
-  *out++ = ASN1_SEQUENCE;
-  *out++ = (rLength + sLength + 4);
-
-  *out++ = ASN1_INTEGER;
-  *out++ = rLength;
-  if ((*r & 0x80) && rLength) {
-    *out++ = 0;
-    rLength--;
-  }
-  memcpy(out, r, rLength);
-  out += rLength;
-
-  *out++ = ASN1_INTEGER;
-  *out++ = sLength;
-  if ((*s & 0x80) && sLength) {
-    *out++ = 0;
-    sLength--;
-  }
-  memcpy(out, s, sLength);
-  out += rLength;
-}
-
-int ECCX08CSRClass::appendName(const String& name, int type, byte out[])
-{
-  int nameLength = name.length();
-
-  *out++ = ASN1_SET;
-  *out++ = nameLength + 9;
-
-  *out++ = ASN1_SEQUENCE;
-  *out++ = nameLength + 7;
-
-  *out++ = ASN1_OBJECT_IDENTIFIER;
-  *out++ = 0x03;
-  *out++ = 0x55;
-  *out++ = 0x04;
-  *out++ = type;
-
-  *out++ = ASN1_PRINTABLE_STRING;
-  *out++ = nameLength;
-  memcpy(out, name.c_str(), nameLength);
-
-  return (nameLength + 11);
-}
-
-void ECCX08CSRClass::appendSequenceHeader(int length, byte out[])
-{
-  *out++ = ASN1_SEQUENCE;
-  if (length > 255) {
-    *out++ = 0x82;
-    *out++ = (length >> 8) & 0xff;
-  } else if (length > 127) {
-    *out++ = 0x81;
-  }
-  *out++ = (length) & 0xff;
-}
 
 ECCX08CSRClass ECCX08CSR;

--- a/src/utility/ECCX08CSR.h
+++ b/src/utility/ECCX08CSR.h
@@ -49,40 +49,6 @@ public:
   void setCommonName(const String& commonName) { setCommonName(commonName.c_str()); }
 
 private:
-  int versionLength();
-
-  int subjectLength(const String& countryName,
-                    const String& stateProvinceName,
-                    const String& localityName,
-                    const String& organizationName,
-                    const String& organizationalUnitName,
-                    const String& commonName);
-
-  int publicKeyLength();
-
-  int signatureLength(const byte signature[]);
-
-  int sequenceHeaderLength(int length);
-
-  void appendVersion(int version, byte out[]);
-
-  void appendSubject(const String& countryName,
-                     const String& stateProvinceName,
-                     const String& localityName,
-                     const String& organizationName,
-                     const String& organizationalUnitName,
-                     const String& commonName,
-                     byte out[]);
-
-   void appendPublicKey(const byte publicKey[], byte out[]);
-
-   void appendSignature(const byte signature[], byte out[]);
-
-   int appendName(const String& name, int type, byte out[]);
-
-   void appendSequenceHeader(int length, byte out[]);
-
-private:
   int _slot;
 
   String _countryName;

--- a/src/utility/ECCX08SelfSignedCert.cpp
+++ b/src/utility/ECCX08SelfSignedCert.cpp
@@ -39,9 +39,11 @@ struct __attribute__((__packed__)) CompressedCert {
   uint8_t unused[5];
 };
 
+static const uint8_t DEFAULT_SERIAL_NUMBER[] = { 0x01 };
+
 ECCX08SelfSignedCertClass::ECCX08SelfSignedCertClass() :
-  _serialNumber(NULL),
-  _serialNumberLength(0),
+  _serialNumber(DEFAULT_SERIAL_NUMBER),
+  _serialNumberLength(sizeof(DEFAULT_SERIAL_NUMBER)),
   _bytes(NULL),
   _length(0)
 {

--- a/src/utility/ECCX08SelfSignedCert.cpp
+++ b/src/utility/ECCX08SelfSignedCert.cpp
@@ -1,0 +1,382 @@
+/*
+  This file is part of the ArduinoECCX08 library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "ArduinoECCX08.h"
+
+#include "ASN1Utils.h"
+#include "PEMUtils.h"
+
+#include "ECCX08SelfSignedCert.h"
+
+struct __attribute__((__packed__)) CompressedCert {
+  uint8_t signature[64];
+  struct {
+    uint8_t year:5;
+    uint8_t month:4;
+    uint8_t day:5;
+    uint8_t hour:5;
+    uint8_t expires:5;
+  } dates;
+  uint8_t unused[5];
+};
+
+ECCX08SelfSignedCertClass::ECCX08SelfSignedCertClass() :
+  _serialNumber(NULL),
+  _serialNumberLength(0),
+  _bytes(NULL),
+  _length(0)
+{
+}
+
+ECCX08SelfSignedCertClass::~ECCX08SelfSignedCertClass()
+{
+  if (_bytes) {
+    free(_bytes);
+    _bytes = NULL;
+  }
+}
+
+int ECCX08SelfSignedCertClass::beginStorage(int keySlot, int dateAndSignatureSlot, bool newKey)
+{
+  if (keySlot < 0 || keySlot > 8) {
+    return 0;
+  }
+
+  if (dateAndSignatureSlot < 8 || dateAndSignatureSlot > 15) {
+    return 0;
+  }
+
+  _keySlot = keySlot;
+  _dateAndSignatureSlot = dateAndSignatureSlot;
+
+  byte publicKey[64];
+
+  if (newKey && !ECCX08.generatePrivateKey(_keySlot, publicKey)) {
+    return 0;
+  }
+
+  return 1;
+}
+
+String ECCX08SelfSignedCertClass::endStorage()
+{
+  if (!buildCert(true)) {
+    return "";
+  }
+
+  return PEMUtils.base64Encode(_bytes, _length, "-----BEGIN CERTIFICATE-----\n", "\n-----END CERTIFICATE-----\n");
+}
+
+int ECCX08SelfSignedCertClass::beginReconstruction(int keySlot, int dateAndSignatureSlot)
+{
+  if (keySlot < 0 || keySlot > 8) {
+    return 0;
+  }
+
+  if (dateAndSignatureSlot < 8 || dateAndSignatureSlot > 15) {
+    return 0;
+  }
+
+  _keySlot = keySlot;
+  _dateAndSignatureSlot = dateAndSignatureSlot;
+
+  if (!ECCX08.readSlot(_dateAndSignatureSlot, _temp, sizeof(_temp))) {
+    return 0;
+  }
+
+  return 1;
+}
+
+int ECCX08SelfSignedCertClass::endReconstruction()
+{
+  if (!buildCert(false)) {
+    return 0;
+  }
+
+  return 1;
+}
+
+uint8_t* ECCX08SelfSignedCertClass::bytes()
+{
+  return _bytes;
+}
+
+int ECCX08SelfSignedCertClass::length()
+{
+  return _length;
+}
+
+void ECCX08SelfSignedCertClass::setIssueYear(int issueYear)
+{
+  struct CompressedCert* compressedCert = (struct CompressedCert*)_temp;
+
+  compressedCert->dates.year = (issueYear - 2000);
+}
+
+void ECCX08SelfSignedCertClass::setIssueMonth(int issueMonth)
+{
+  struct CompressedCert* compressedCert = (struct CompressedCert*)_temp;
+
+  compressedCert->dates.month = issueMonth;
+}
+
+void ECCX08SelfSignedCertClass::setIssueDay(int issueDay)
+{
+  struct CompressedCert* compressedCert = (struct CompressedCert*)_temp;
+
+  compressedCert->dates.day = issueDay;
+}
+
+void ECCX08SelfSignedCertClass::setIssueHour(int issueHour)
+{
+  struct CompressedCert* compressedCert = (struct CompressedCert*)_temp;
+
+  compressedCert->dates.hour = issueHour;
+}
+
+void ECCX08SelfSignedCertClass::setExpireYears(int expireYears)
+{
+  struct CompressedCert* compressedCert = (struct CompressedCert*)_temp;
+
+  compressedCert->dates.expires = expireYears;
+}
+
+void ECCX08SelfSignedCertClass::setSerialNumber(const byte serialNumber[], int length)
+{
+  _serialNumber = serialNumber;
+  _serialNumberLength = length;
+}
+
+void ECCX08SelfSignedCertClass::setCountryName(const char *countryName)
+{
+  _countryName = countryName;
+}
+
+void ECCX08SelfSignedCertClass::setStateProvinceName(const char* stateProvinceName)
+{
+  _stateProvinceName = stateProvinceName;
+}
+
+void ECCX08SelfSignedCertClass::setLocalityName(const char* localityName)
+{
+  _localityName = localityName;
+}
+
+void ECCX08SelfSignedCertClass::setOrganizationName(const char* organizationName)
+{
+  _organizationName = organizationName;
+}
+
+void ECCX08SelfSignedCertClass::setOrganizationalUnitName(const char* organizationalUnitName)
+{
+  _organizationalUnitName = organizationalUnitName;
+}
+
+void ECCX08SelfSignedCertClass::setCommonName(const char* commonName)
+{
+  _commonName = commonName;
+}
+
+int ECCX08SelfSignedCertClass::buildCert(bool buildSignature)
+{
+  uint8_t publicKey[64];
+
+  if (!ECCX08.generatePublicKey(_keySlot, publicKey)) {
+    return 0;
+  }
+
+  int certInfoLen = certInfoLength();
+  int certInfoHeaderLen = ASN1Utils.sequenceHeaderLength(certInfoLen);
+
+  uint8_t certInfo[certInfoLen + certInfoHeaderLen];
+
+  appendCertInfo(publicKey, certInfo, certInfoLen);
+  
+  if (buildSignature) {
+    byte certInfoSha256[64];
+
+    memset(certInfoSha256, 0x00, sizeof(certInfoSha256));
+
+    if (!ECCX08.beginSHA256()) {
+      return 0;
+    }
+
+    for (int i = 0; i < (certInfoHeaderLen + certInfoLen); i += 64) {
+      int chunkLength = (certInfoHeaderLen + certInfoLen) - i;
+
+      if (chunkLength > 64) {
+        chunkLength = 64;
+      }
+
+      if (chunkLength == 64) {
+        if (!ECCX08.updateSHA256(&certInfo[i])) {
+          return 0;
+        }
+      } else {
+        if (!ECCX08.endSHA256(&certInfo[i], chunkLength, certInfoSha256)) {
+          return 0;
+        }
+      }
+    }
+
+    if (!ECCX08.ecSign(_keySlot, certInfoSha256, _temp)) {
+      return 0;
+    }
+
+    if (!ECCX08.writeSlot(_dateAndSignatureSlot, _temp, sizeof(_temp))) {
+      return 0;
+    }
+  }
+
+  int signatureLen = ASN1Utils.signatureLength(_temp);
+
+  int certDataLen = certInfoLen + certInfoHeaderLen + signatureLen;
+  int certDataHeaderLen = ASN1Utils.sequenceHeaderLength(certDataLen);
+
+  _length = certDataLen + certDataHeaderLen;
+  _bytes = (byte*)realloc(_bytes, _length);
+
+  if (!_bytes) {
+    _length = 0;
+    return 0;
+  }
+
+  uint8_t* out = _bytes;
+
+  out += ASN1Utils.appendSequenceHeader(certDataLen, out);
+
+  memcpy(out, certInfo, certInfoHeaderLen + certInfoLen);
+  out += (certInfoHeaderLen + certInfoLen);
+
+  // signature
+  out += ASN1Utils.appendSignature(_temp, out);
+
+  return 1;
+}
+
+int ECCX08SelfSignedCertClass::certInfoLength()
+{
+  struct CompressedCert* compressedCert = (struct CompressedCert*)_temp;
+
+  int year = (compressedCert->dates.year + 2000);
+  int expireYears = compressedCert->dates.expires;
+
+  int datesSize = 30;
+
+  if (year > 2049) {
+    // two more bytes for GeneralizedTime
+    datesSize += 2;
+  }
+
+  if ((year + expireYears) > 2049) {
+    // two more bytes for GeneralizedTime
+    datesSize += 2;
+  }
+
+  int serialNumberLen = ASN1Utils.serialNumberLength(_serialNumber, _serialNumberLength);
+
+  int issuerAndSubjectLen = ASN1Utils.issuerOrSubjectLength(_countryName,
+                                                            _stateProvinceName,
+                                                            _localityName,
+                                                            _organizationName,
+                                                            _organizationalUnitName,
+                                                            _commonName);
+
+  int issuerAndSubjectHeaderLen = ASN1Utils.sequenceHeaderLength(issuerAndSubjectLen);
+
+
+  int publicKeyLen = ASN1Utils.publicKeyLength();
+  
+
+  int certInfoLen = 5 + serialNumberLen + 12 + 
+                    2 * (issuerAndSubjectHeaderLen + issuerAndSubjectLen) + 
+                    (datesSize + 2) + publicKeyLen + 4;
+
+  return certInfoLen;
+}
+
+void ECCX08SelfSignedCertClass::appendCertInfo(uint8_t publicKey[], uint8_t buffer[], int length)
+{
+  struct CompressedCert* compressedCert = (struct CompressedCert*)_temp;
+  uint8_t* out = buffer;
+
+  // dates
+  int year = (compressedCert->dates.year + 2000);
+  int month = compressedCert->dates.month;
+  int day = compressedCert->dates.day;
+  int hour = compressedCert->dates.hour;
+  int expireYears = compressedCert->dates.expires;
+
+  out += ASN1Utils.appendSequenceHeader(length, out);
+
+  // version
+  *out++ = 0xA0;
+  *out++ = 0x03;
+  *out++ = 0x02;
+  *out++ = 0x01;
+  *out++ = 0x02;
+
+  // serial number
+  out += ASN1Utils.appendSerialNumber(_serialNumber, _serialNumberLength, out);
+
+  out += ASN1Utils.appendEcdsaWithSHA256(out);
+
+  // issuer
+  int issuerAndSubjectLen = ASN1Utils.issuerOrSubjectLength(_countryName,
+                                                            _stateProvinceName,
+                                                            _localityName,
+                                                            _organizationName,
+                                                            _organizationalUnitName,
+                                                            _commonName);
+
+  out += ASN1Utils.appendSequenceHeader(issuerAndSubjectLen, out);
+  ASN1Utils.appendIssuerOrSubject(_countryName,
+                                  _stateProvinceName,
+                                  _localityName,
+                                  _organizationName,
+                                  _organizationalUnitName,
+                                  _commonName, out);
+  out += issuerAndSubjectLen;
+
+  *out++ = ASN1_SEQUENCE;
+  *out++ = 30 + ((year > 2049) ? 2 : 0) + (((year + expireYears) > 2049) ? 2 : 0);
+  out += ASN1Utils.appendDate(year, month, day, hour, 0, 0, out);
+  out += ASN1Utils.appendDate(year + expireYears, month, day, hour, 0, 0, out);
+
+  // subject
+  out += ASN1Utils.appendSequenceHeader(issuerAndSubjectLen, out);
+  ASN1Utils.appendIssuerOrSubject(_countryName,
+                                  _stateProvinceName,
+                                  _localityName,
+                                  _organizationName,
+                                  _organizationalUnitName,
+                                  _commonName, out);
+  out += issuerAndSubjectLen;
+
+  // public key
+  out += ASN1Utils.appendPublicKey(publicKey, out);
+
+  // null sequence
+  *out++ = 0xA3;
+  *out++ = 0x02;
+  *out++ = 0x30;
+  *out++ = 0x00;
+}
+
+ECCX08SelfSignedCertClass ECCX08SelfSignedCert;

--- a/src/utility/ECCX08SelfSignedCert.cpp
+++ b/src/utility/ECCX08SelfSignedCert.cpp
@@ -19,6 +19,9 @@
 
 #include "ArduinoECCX08.h"
 
+extern "C" {
+  #include "sha1.h"
+}
 #include "ASN1Utils.h"
 #include "PEMUtils.h"
 
@@ -120,6 +123,28 @@ uint8_t* ECCX08SelfSignedCertClass::bytes()
 int ECCX08SelfSignedCertClass::length()
 {
   return _length;
+}
+
+String ECCX08SelfSignedCertClass::sha1()
+{
+  char result[20 + 1];
+
+  SHA1(result, (const char*)_bytes, _length);
+
+  String sha1Str;
+
+  sha1Str.reserve(40);
+
+  for (int i = 0; i < 20; i++) {
+    uint8_t b = result[i];
+
+    if (b < 16) {
+      sha1Str += '0';
+    }
+    sha1Str += String(b, HEX);
+  }
+
+  return sha1Str;
 }
 
 void ECCX08SelfSignedCertClass::setIssueYear(int issueYear)

--- a/src/utility/ECCX08SelfSignedCert.h
+++ b/src/utility/ECCX08SelfSignedCert.h
@@ -36,6 +36,8 @@ public:
   uint8_t* bytes();
   int length();
 
+  String sha1();
+
   void setIssueYear(int issueYear);
   void setIssueMonth(int issueMonth);
   void setIssueDay(int issueDay);

--- a/src/utility/ECCX08SelfSignedCert.h
+++ b/src/utility/ECCX08SelfSignedCert.h
@@ -1,0 +1,91 @@
+/*
+  This file is part of the ArduinoECCX08 library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _ECCX08_SELF_SIGNED_CERT_H_
+#define _ECCX08_SELF_SIGNED_CERT_H_
+
+#include <Arduino.h>
+
+class ECCX08SelfSignedCertClass {
+public:
+  ECCX08SelfSignedCertClass();
+  virtual ~ECCX08SelfSignedCertClass();
+
+  int beginStorage(int keySlot, int dateAndSignatureSlot, bool newKey);
+  String endStorage();
+
+  int beginReconstruction(int keySlot, int dateAndSignatureSlot);
+  int endReconstruction();
+
+  uint8_t* bytes();
+  int length();
+
+  void setIssueYear(int issueYear);
+  void setIssueMonth(int issueMonth);
+  void setIssueDay(int issueDay);
+  void setIssueHour(int issueHour);
+  void setExpireYears(int expireYears);
+  void setSerialNumber(const uint8_t serialNumber[], int length);
+
+  void setCountryName(const char *countryName);
+  void setCountryName(const String& countryName) { setCountryName(countryName.c_str()); }
+
+  void setStateProvinceName(const char* stateProvinceName);
+  void setStateProvinceName(const String& stateProvinceName) { setStateProvinceName(stateProvinceName.c_str()); }
+
+  void setLocalityName(const char* localityName);
+  void setLocalityName(const String& localityName) { setLocalityName(localityName.c_str()); }
+
+  void setOrganizationName(const char* organizationName);
+  void setOrganizationName(const String& organizationName) { setOrganizationName(organizationName.c_str()); }
+
+  void setOrganizationalUnitName(const char* organizationalUnitName);
+  void setOrganizationalUnitName(const String& organizationalUnitName) { setOrganizationalUnitName(organizationalUnitName.c_str()); }
+
+  void setCommonName(const char* commonName);
+  void setCommonName(const String& commonName) { setCommonName(commonName.c_str()); }
+
+private:
+  int buildCert(bool buildSignature);
+
+  int certInfoLength();
+  void appendCertInfo(uint8_t publicKey[], uint8_t buffer[], int length);
+
+private:
+  int _keySlot;
+  int _dateAndSignatureSlot;
+
+  String _countryName;
+  String _stateProvinceName;
+  String _localityName;
+  String _organizationName;
+  String _organizationalUnitName;
+  String _commonName;
+
+  uint8_t _temp[72];
+  const uint8_t* _serialNumber;
+  int _serialNumberLength;
+
+  uint8_t* _bytes;
+  int _length;
+};
+
+extern ECCX08SelfSignedCertClass ECCX08SelfSignedCert;
+
+#endif

--- a/src/utility/PEMUtils.cpp
+++ b/src/utility/PEMUtils.cpp
@@ -1,0 +1,71 @@
+/*
+  This file is part of the ArduinoECCX08 library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "PEMUtils.h"
+
+String PEMUtilsClass::base64Encode(const byte in[], unsigned int length, const char* prefix, const char* suffix)
+{
+  static const char* CODES = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+  int b;
+  String out;
+
+  int reserveLength = 4 * ((length + 2) / 3) + ((length / 3 * 4) / 76) + strlen(prefix) + strlen(suffix);
+  out.reserve(reserveLength);
+
+  if (prefix) {
+    out += prefix;
+  }
+  
+  for (unsigned int i = 0; i < length; i += 3) {
+    if (i > 0 && (i / 3 * 4) % 76 == 0) { 
+      out += '\n'; 
+    }
+
+    b = (in[i] & 0xFC) >> 2;
+    out += CODES[b];
+
+    b = (in[i] & 0x03) << 4;
+    if (i + 1 < length) {
+      b |= (in[i + 1] & 0xF0) >> 4;
+      out += CODES[b];
+      b = (in[i + 1] & 0x0F) << 2;
+      if (i + 2 < length) {
+         b |= (in[i + 2] & 0xC0) >> 6;
+         out += CODES[b];
+         b = in[i + 2] & 0x3F;
+         out += CODES[b];
+      } else {
+        out += CODES[b];
+        out += '=';
+      }
+    } else {
+      out += CODES[b];
+      out += "==";
+    }
+  }
+
+  if (suffix) {
+    out += suffix;
+  }
+
+  return out;
+}
+
+PEMUtilsClass PEMUtils;

--- a/src/utility/PEMUtils.h
+++ b/src/utility/PEMUtils.h
@@ -1,0 +1,32 @@
+/*
+  This file is part of the ArduinoECCX08 library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _PEM_UTILS_H_
+#define _PEM_UTILS_H_
+
+#include <Arduino.h>
+
+class PEMUtilsClass {
+public:
+   String base64Encode(const byte in[], unsigned int length, const char* prefix, const char* suffix);
+};
+
+extern PEMUtilsClass PEMUtils;
+
+#endif

--- a/src/utility/sha1.c
+++ b/src/utility/sha1.c
@@ -1,0 +1,296 @@
+/*
+SHA-1 in C
+By Steve Reid <steve@edmweb.com>
+100% Public Domain
+
+Test Vectors (from FIPS PUB 180-1)
+"abc"
+  A9993E36 4706816A BA3E2571 7850C26C 9CD0D89D
+"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+  84983E44 1C3BD26E BAAE4AA1 F95129E5 E54670F1
+A million repetitions of "a"
+  34AA973C D4C4DAA4 F61EEB2B DBAD2731 6534016F
+*/
+
+/* #define LITTLE_ENDIAN * This should be #define'd already, if true. */
+/* #define SHA1HANDSOFF * Copies data before messing with it. */
+
+#define SHA1HANDSOFF
+
+#include <stdio.h>
+#include <string.h>
+
+/* for uint32_t */
+#include <stdint.h>
+
+#include "sha1.h"
+
+
+#define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))
+
+/* blk0() and blk() perform the initial expand. */
+/* I got the idea of expanding during the round function from SSLeay */
+#if BYTE_ORDER == LITTLE_ENDIAN
+#define blk0(i) (block->l[i] = (rol(block->l[i],24)&0xFF00FF00) \
+    |(rol(block->l[i],8)&0x00FF00FF))
+#elif BYTE_ORDER == BIG_ENDIAN
+#define blk0(i) block->l[i]
+#else
+#error "Endianness not defined!"
+#endif
+#define blk(i) (block->l[i&15] = rol(block->l[(i+13)&15]^block->l[(i+8)&15] \
+    ^block->l[(i+2)&15]^block->l[i&15],1))
+
+/* (R0+R1), R2, R3, R4 are the different operations used in SHA1 */
+#define R0(v,w,x,y,z,i) z+=((w&(x^y))^y)+blk0(i)+0x5A827999+rol(v,5);w=rol(w,30);
+#define R1(v,w,x,y,z,i) z+=((w&(x^y))^y)+blk(i)+0x5A827999+rol(v,5);w=rol(w,30);
+#define R2(v,w,x,y,z,i) z+=(w^x^y)+blk(i)+0x6ED9EBA1+rol(v,5);w=rol(w,30);
+#define R3(v,w,x,y,z,i) z+=(((w|x)&y)|(w&x))+blk(i)+0x8F1BBCDC+rol(v,5);w=rol(w,30);
+#define R4(v,w,x,y,z,i) z+=(w^x^y)+blk(i)+0xCA62C1D6+rol(v,5);w=rol(w,30);
+
+
+/* Hash a single 512-bit block. This is the core of the algorithm. */
+
+void SHA1Transform(
+    uint32_t state[5],
+    const unsigned char buffer[64]
+)
+{
+    uint32_t a, b, c, d, e;
+
+    typedef union
+    {
+        unsigned char c[64];
+        uint32_t l[16];
+    } CHAR64LONG16;
+
+#ifdef SHA1HANDSOFF
+    CHAR64LONG16 block[1];      /* use array to appear as a pointer */
+
+    memcpy(block, buffer, 64);
+#else
+    /* The following had better never be used because it causes the
+     * pointer-to-const buffer to be cast into a pointer to non-const.
+     * And the result is written through.  I threw a "const" in, hoping
+     * this will cause a diagnostic.
+     */
+    CHAR64LONG16 *block = (const CHAR64LONG16 *) buffer;
+#endif
+    /* Copy context->state[] to working vars */
+    a = state[0];
+    b = state[1];
+    c = state[2];
+    d = state[3];
+    e = state[4];
+    /* 4 rounds of 20 operations each. Loop unrolled. */
+    R0(a, b, c, d, e, 0);
+    R0(e, a, b, c, d, 1);
+    R0(d, e, a, b, c, 2);
+    R0(c, d, e, a, b, 3);
+    R0(b, c, d, e, a, 4);
+    R0(a, b, c, d, e, 5);
+    R0(e, a, b, c, d, 6);
+    R0(d, e, a, b, c, 7);
+    R0(c, d, e, a, b, 8);
+    R0(b, c, d, e, a, 9);
+    R0(a, b, c, d, e, 10);
+    R0(e, a, b, c, d, 11);
+    R0(d, e, a, b, c, 12);
+    R0(c, d, e, a, b, 13);
+    R0(b, c, d, e, a, 14);
+    R0(a, b, c, d, e, 15);
+    R1(e, a, b, c, d, 16);
+    R1(d, e, a, b, c, 17);
+    R1(c, d, e, a, b, 18);
+    R1(b, c, d, e, a, 19);
+    R2(a, b, c, d, e, 20);
+    R2(e, a, b, c, d, 21);
+    R2(d, e, a, b, c, 22);
+    R2(c, d, e, a, b, 23);
+    R2(b, c, d, e, a, 24);
+    R2(a, b, c, d, e, 25);
+    R2(e, a, b, c, d, 26);
+    R2(d, e, a, b, c, 27);
+    R2(c, d, e, a, b, 28);
+    R2(b, c, d, e, a, 29);
+    R2(a, b, c, d, e, 30);
+    R2(e, a, b, c, d, 31);
+    R2(d, e, a, b, c, 32);
+    R2(c, d, e, a, b, 33);
+    R2(b, c, d, e, a, 34);
+    R2(a, b, c, d, e, 35);
+    R2(e, a, b, c, d, 36);
+    R2(d, e, a, b, c, 37);
+    R2(c, d, e, a, b, 38);
+    R2(b, c, d, e, a, 39);
+    R3(a, b, c, d, e, 40);
+    R3(e, a, b, c, d, 41);
+    R3(d, e, a, b, c, 42);
+    R3(c, d, e, a, b, 43);
+    R3(b, c, d, e, a, 44);
+    R3(a, b, c, d, e, 45);
+    R3(e, a, b, c, d, 46);
+    R3(d, e, a, b, c, 47);
+    R3(c, d, e, a, b, 48);
+    R3(b, c, d, e, a, 49);
+    R3(a, b, c, d, e, 50);
+    R3(e, a, b, c, d, 51);
+    R3(d, e, a, b, c, 52);
+    R3(c, d, e, a, b, 53);
+    R3(b, c, d, e, a, 54);
+    R3(a, b, c, d, e, 55);
+    R3(e, a, b, c, d, 56);
+    R3(d, e, a, b, c, 57);
+    R3(c, d, e, a, b, 58);
+    R3(b, c, d, e, a, 59);
+    R4(a, b, c, d, e, 60);
+    R4(e, a, b, c, d, 61);
+    R4(d, e, a, b, c, 62);
+    R4(c, d, e, a, b, 63);
+    R4(b, c, d, e, a, 64);
+    R4(a, b, c, d, e, 65);
+    R4(e, a, b, c, d, 66);
+    R4(d, e, a, b, c, 67);
+    R4(c, d, e, a, b, 68);
+    R4(b, c, d, e, a, 69);
+    R4(a, b, c, d, e, 70);
+    R4(e, a, b, c, d, 71);
+    R4(d, e, a, b, c, 72);
+    R4(c, d, e, a, b, 73);
+    R4(b, c, d, e, a, 74);
+    R4(a, b, c, d, e, 75);
+    R4(e, a, b, c, d, 76);
+    R4(d, e, a, b, c, 77);
+    R4(c, d, e, a, b, 78);
+    R4(b, c, d, e, a, 79);
+    /* Add the working vars back into context.state[] */
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    /* Wipe variables */
+    a = b = c = d = e = 0;
+#ifdef SHA1HANDSOFF
+    memset(block, '\0', sizeof(block));
+#endif
+}
+
+
+/* SHA1Init - Initialize new context */
+
+void SHA1Init(
+    SHA1_CTX * context
+)
+{
+    /* SHA1 initialization constants */
+    context->state[0] = 0x67452301;
+    context->state[1] = 0xEFCDAB89;
+    context->state[2] = 0x98BADCFE;
+    context->state[3] = 0x10325476;
+    context->state[4] = 0xC3D2E1F0;
+    context->count[0] = context->count[1] = 0;
+}
+
+
+/* Run your data through this. */
+
+void SHA1Update(
+    SHA1_CTX * context,
+    const unsigned char *data,
+    uint32_t len
+)
+{
+    uint32_t i;
+
+    uint32_t j;
+
+    j = context->count[0];
+    if ((context->count[0] += len << 3) < j)
+        context->count[1]++;
+    context->count[1] += (len >> 29);
+    j = (j >> 3) & 63;
+    if ((j + len) > 63)
+    {
+        memcpy(&context->buffer[j], data, (i = 64 - j));
+        SHA1Transform(context->state, context->buffer);
+        for (; i + 63 < len; i += 64)
+        {
+            SHA1Transform(context->state, &data[i]);
+        }
+        j = 0;
+    }
+    else
+        i = 0;
+    memcpy(&context->buffer[j], &data[i], len - i);
+}
+
+
+/* Add padding and return the message digest. */
+
+void SHA1Final(
+    unsigned char digest[20],
+    SHA1_CTX * context
+)
+{
+    unsigned i;
+
+    unsigned char finalcount[8];
+
+    unsigned char c;
+
+#if 0    /* untested "improvement" by DHR */
+    /* Convert context->count to a sequence of bytes
+     * in finalcount.  Second element first, but
+     * big-endian order within element.
+     * But we do it all backwards.
+     */
+    unsigned char *fcp = &finalcount[8];
+
+    for (i = 0; i < 2; i++)
+    {
+        uint32_t t = context->count[i];
+
+        int j;
+
+        for (j = 0; j < 4; t >>= 8, j++)
+            *--fcp = (unsigned char) t}
+#else
+    for (i = 0; i < 8; i++)
+    {
+        finalcount[i] = (unsigned char) ((context->count[(i >= 4 ? 0 : 1)] >> ((3 - (i & 3)) * 8)) & 255);      /* Endian independent */
+    }
+#endif
+    c = 0200;
+    SHA1Update(context, &c, 1);
+    while ((context->count[0] & 504) != 448)
+    {
+        c = 0000;
+        SHA1Update(context, &c, 1);
+    }
+    SHA1Update(context, finalcount, 8); /* Should cause a SHA1Transform() */
+    for (i = 0; i < 20; i++)
+    {
+        digest[i] = (unsigned char)
+            ((context->state[i >> 2] >> ((3 - (i & 3)) * 8)) & 255);
+    }
+    /* Wipe variables */
+    memset(context, '\0', sizeof(*context));
+    memset(&finalcount, '\0', sizeof(finalcount));
+}
+
+void SHA1(
+    char *hash_out,
+    const char *str,
+    int len)
+{
+    SHA1_CTX ctx;
+    unsigned int ii;
+
+    SHA1Init(&ctx);
+    for (ii=0; ii<len; ii+=1)
+        SHA1Update(&ctx, (const unsigned char*)str + ii, 1);
+    SHA1Final((unsigned char *)hash_out, &ctx);
+    hash_out[20] = '\0';
+}
+

--- a/src/utility/sha1.c
+++ b/src/utility/sha1.c
@@ -285,7 +285,11 @@ void SHA1(
     int len)
 {
     SHA1_CTX ctx;
+#ifdef ARDUINO
+    int ii;
+#else
     unsigned int ii;
+#endif
 
     SHA1Init(&ctx);
     for (ii=0; ii<len; ii+=1)

--- a/src/utility/sha1.h
+++ b/src/utility/sha1.h
@@ -1,0 +1,44 @@
+#ifndef SHA1_H
+#define SHA1_H
+
+/*
+   SHA-1 in C
+   By Steve Reid <steve@edmweb.com>
+   100% Public Domain
+ */
+
+#include "stdint.h"
+
+typedef struct
+{
+    uint32_t state[5];
+    uint32_t count[2];
+    unsigned char buffer[64];
+} SHA1_CTX;
+
+void SHA1Transform(
+    uint32_t state[5],
+    const unsigned char buffer[64]
+    );
+
+void SHA1Init(
+    SHA1_CTX * context
+    );
+
+void SHA1Update(
+    SHA1_CTX * context,
+    const unsigned char *data,
+    uint32_t len
+    );
+
+void SHA1Final(
+    unsigned char digest[20],
+    SHA1_CTX * context
+    );
+
+void SHA1(
+    char *hash_out,
+    const char *str,
+    int len);
+
+#endif /* SHA1_H */


### PR DESCRIPTION
This pull request, adds a new sketch and support to creating, storing and re-constructing a self signed certificate for a private key slot, another slot is used to persist the dates and signature for the self signed certificate.

Utils from the CSR code was split out, so they could be re-used. 