### PR TITLE
Put device to sleep when calling end()

### DIFF
--- a/src/ECCX08.cpp
+++ b/src/ECCX08.cpp
@@ -56,6 +56,9 @@ int ECCX08Class::begin()
 
 void ECCX08Class::end()
 {
+  // First wake up the device otherwise the chip didn't react to a sleep commando
+  wakeup();
+  sleep();
 #ifdef WIRE_HAS_END
   _wire->end();
 #endif


### PR DESCRIPTION
ECCX08.end() currently only ends the i2c communication if supported, but leaves the crypto chip in idle mode. 

This merge request wake up the device to be sure that the device is awake and sends a sleep commando that results in a sub 5 uA sleep current of the crypto chip and Arduino combined.