### PR TITLE
Add JWS support utilty and setup sketch

### DIFF
--- a/examples/Tools/ECCX08JWSPublicKey/ECCX08JWSPublicKey.ino
+++ b/examples/Tools/ECCX08JWSPublicKey/ECCX08JWSPublicKey.ino
@@ -1,0 +1,118 @@
+/*
+  ArduinoECCX08 - JWS Public Key
+
+  This sketch can be used to generate a PEM public key for a private key
+  generated in an ECC508/ECC608 crypto chip slot.
+
+  If the ECC508/ECC608 is not configured and locked it prompts
+  the user to configure and lock the chip with a default TLS
+  configuration.
+
+  The user can also select a slot number to use for the private key
+  A new private key can also be generated in this slot.
+
+  The circuit:
+  - Arduino MKR board equipped with ECC508 or ECC608 chip
+
+  This example code is in the public domain.
+*/
+
+#include <ArduinoECCX08.h>
+#include <utility/ECCX08JWS.h>
+#include <utility/ECCX08DefaultTLSConfig.h>
+
+void setup() {
+  Serial.begin(9600);
+  while (!Serial);
+
+  if (!ECCX08.begin()) {
+    Serial.println("No ECCX08 present!");
+    while (1);
+  }
+
+  if (!ECCX08.locked()) {
+    String lock = promptAndReadLine("The ECCX08 on your board is not locked, would you like to PERMANENTLY configure and lock it now? (y/N)", "N");
+    lock.toLowerCase();
+
+    if (!lock.startsWith("y")) {
+      Serial.println("Unfortunately you can't proceed without locking it :(");
+      while (1);
+    }
+
+    if (!ECCX08.writeConfiguration(ECCX08_DEFAULT_TLS_CONFIG)) {
+      Serial.println("Writing ECCX08 configuration failed!");
+      while (1);
+    }
+
+    if (!ECCX08.lock()) {
+      Serial.println("Locking ECCX08 configuration failed!");
+      while (1);
+    }
+
+    Serial.println("ECCX08 locked successfully");
+    Serial.println();
+  }
+
+  Serial.println("Hi there, in order to generate a PEM public key for your board, we'll need the following information ...");
+  Serial.println();
+
+  String slot               = promptAndReadLine("What slot would you like to use? (0 - 4)", "0");
+  String generateNewKey     = promptAndReadLine("Would you like to generate a new private key? (Y/n)", "Y");
+
+  Serial.println();
+
+  generateNewKey.toLowerCase();
+
+  String publicKeyPem = ECCX08JWS.publicKey(slot.toInt(), generateNewKey.startsWith("y"));
+
+  if (!publicKeyPem || publicKeyPem == "") {
+    Serial.println("Error generating public key!");
+    while (1);
+  }
+
+  Serial.println("Here's your public key PEM, enjoy!");
+  Serial.println();
+  Serial.println(publicKeyPem);
+}
+
+void loop() {
+  // do nothing
+}
+
+String promptAndReadLine(const char* prompt, const char* defaultValue) {
+  Serial.print(prompt);
+  Serial.print(" [");
+  Serial.print(defaultValue);
+  Serial.print("]: ");
+
+  String s = readLine();
+
+  if (s.length() == 0) {
+    s = defaultValue;
+  }
+
+  Serial.println(s);
+
+  return s;
+}
+
+String readLine() {
+  String line;
+
+  while (1) {
+    if (Serial.available()) {
+      char c = Serial.read();
+
+      if (c == '\r') {
+        // ignore
+        continue;
+      } else if (c == '\n') {
+        break;
+      }
+
+      line += c;
+    }
+  }
+
+  return line;
+}

--- a/src/utility/ECCX08JWS.cpp
+++ b/src/utility/ECCX08JWS.cpp
@@ -1,0 +1,163 @@
+/*
+  This file is part of the ArduinoECCX08 library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "ECCX08.h"
+
+#include "ASN1Utils.h"
+#include "PEMUtils.h"
+
+#include "ECCX08JWS.h"
+
+static String base64urlEncode(const byte in[], unsigned int length)
+{
+  static const char* CODES = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=";
+
+  int b;
+  String out;
+
+  int reserveLength = 4 * ((length + 2) / 3);
+  out.reserve(reserveLength);
+
+  for (unsigned int i = 0; i < length; i += 3) {
+    b = (in[i] & 0xFC) >> 2;
+    out += CODES[b];
+
+    b = (in[i] & 0x03) << 4;
+    if (i + 1 < length) {
+      b |= (in[i + 1] & 0xF0) >> 4;
+      out += CODES[b];
+      b = (in[i + 1] & 0x0F) << 2;
+      if (i + 2 < length) {
+         b |= (in[i + 2] & 0xC0) >> 6;
+         out += CODES[b];
+         b = in[i + 2] & 0x3F;
+         out += CODES[b];
+      } else {
+        out += CODES[b];
+      }
+    } else {
+      out += CODES[b];
+    }
+  }
+
+  while (out.lastIndexOf('=') != -1) {
+    out.remove(out.length() - 1);
+  }
+
+  return out;
+}
+
+ECCX08JWSClass::ECCX08JWSClass()
+{
+}
+
+ECCX08JWSClass::~ECCX08JWSClass()
+{
+}
+
+String ECCX08JWSClass::publicKey(int slot, bool newPrivateKey)
+{
+  if (slot < 0 || slot > 8) {
+    return "";
+  }
+
+  byte publicKey[64];
+
+  if (newPrivateKey) {
+    if (!ECCX08.generatePrivateKey(slot, publicKey)) {
+      return "";
+    }
+  } else {
+    if (!ECCX08.generatePublicKey(slot, publicKey)) {
+      return "";
+    }
+  }
+
+  int length = ASN1Utils.publicKeyLength();
+  byte out[length];
+
+  ASN1Utils.appendPublicKey(publicKey, out);
+
+  return PEMUtils.base64Encode(out, length, "-----BEGIN PUBLIC KEY-----\n", "\n-----END PUBLIC KEY-----\n");
+}
+
+String ECCX08JWSClass::sign(int slot, const char* header, const char* payload)
+{
+  if (slot < 0 || slot > 8) {
+    return "";
+  }
+
+  String encodedHeader = base64urlEncode((const byte*)header, strlen(header));
+  String encodedPayload = base64urlEncode((const byte*)payload, strlen(payload));
+
+  String toSign;
+  toSign.reserve(encodedHeader.length() + 1 + encodedPayload.length());
+
+  toSign += encodedHeader;
+  toSign += '.';
+  toSign += encodedPayload;
+
+
+  byte toSignSha256[32];
+  byte signature[64];
+
+  if (!ECCX08.beginSHA256()) {
+    return "";
+  }
+
+  for (unsigned int i = 0; i < toSign.length(); i += 64) {
+    int chunkLength = toSign.length() - i;
+
+    if (chunkLength > 64) {
+      chunkLength = 64;
+    }
+
+    if (chunkLength == 64) {
+      if (!ECCX08.updateSHA256((const byte*)toSign.c_str() + i)) {
+        return "";
+      }
+    } else {
+      if (!ECCX08.endSHA256((const byte*)toSign.c_str() + i, chunkLength, toSignSha256)) {
+        return "";
+      }
+    }
+  }
+
+  if (!ECCX08.ecSign(slot, toSignSha256, signature)) {
+    return "";
+  }
+
+  String encodedSignature = base64urlEncode(signature, sizeof(signature));
+
+  String result;
+  result.reserve(toSign.length() + 1 + encodedSignature.length());
+
+  result += toSign;
+  result += '.';
+  result += encodedSignature;
+
+  return result;
+}
+
+String ECCX08JWSClass::sign(int slot, const String& header, const String& payload)
+{
+  return sign(slot, header.c_str(), payload.c_str());
+}
+
+ECCX08JWSClass ECCX08JWS;

--- a/src/utility/ECCX08JWS.h
+++ b/src/utility/ECCX08JWS.h
@@ -1,0 +1,38 @@
+/*
+  This file is part of the ArduinoECCX08 library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _ECCX08_JWS_H_
+#define _ECCX08_JWS_H_
+
+#include <Arduino.h>
+
+class ECCX08JWSClass {
+public:
+  ECCX08JWSClass();
+  virtual ~ECCX08JWSClass();
+
+  String publicKey(int slot, bool newPrivateKey = true);
+
+  String sign(int slot, const char* header, const char* payload);
+  String sign(int slot, const String& header, const String& payload);
+};
+
+extern ECCX08JWSClass ECCX08JWS;
+
+#endif


### PR DESCRIPTION
Implements support for "JWS Using ECDSA P-256 SHA-256": https://tools.ietf.org/html/rfc7515#appendix-A.3

There is also a setup sketch to generate a private key (optionally) and print a PEM public key for a ECCx08 slot.