### PR TITLE
Define SHA1 function as SHA1_ to make it a "private" symbol when building on Arduino

### DIFF
--- a/src/utility/sha1.h
+++ b/src/utility/sha1.h
@@ -36,6 +36,10 @@ void SHA1Final(
     SHA1_CTX * context
     );
 
+#ifdef ARDUINO
+#define SHA1 SHA1_ // to make the function "internal"
+#endif
+
 void SHA1(
     char *hash_out,
     const char *str,


### PR DESCRIPTION
This avoids having a global `SHA1` symbol so another library can define it.

Note: the SHA1 code is needed for the self signed certificate sketch because Azure IoT Hub needs a SHA1.