### PR TITLE
Adding 'mbed' as supported library to ArduinoECCX008 library

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino Library for the Atmel/Microchip ECC508 and ECC608 crypto chips
 paragraph=
 category=Communication
 url=https://github.com/arduino-libraries/ArduinoECCX08
-architectures=samd,megaavr
+architectures=samd,megaavr,mbed
 includes=ArduinoECCX08.h


### PR DESCRIPTION
Note: We are already using it on Portenta H7.