### PR TITLE
Fix typos in documentation

### DIFF
--- a/examples/ECCX08HMAC/ECCX08HMAC.ino
+++ b/examples/ECCX08HMAC/ECCX08HMAC.ino
@@ -1,7 +1,7 @@
 /*
     ECCX08 HMAC functionality example
 
-    This sketch uses the ECC608 to generate an hmac on some data.
+    This sketch uses the ECC608 to generate an HMAC on some data.
     Stores key using nonce.
 
     Tested on the Arduino Nano RP2040.

--- a/examples/ECCX08RandomNumber/ECCX08RandomNumber.ino
+++ b/examples/ECCX08RandomNumber/ECCX08RandomNumber.ino
@@ -2,7 +2,7 @@
   ECCX08 Random Number
 
   This sketch uses the ECC508 or ECC608 to generate a random number 
-  every second and print it to the Serial monitor
+  every second and print it to the Serial Monitor
 
   Circuit:
    - MKR board with ECC508 or ECC608 on board

--- a/examples/ECCX08Signing/ECCX08Signing.ino
+++ b/examples/ECCX08Signing/ECCX08Signing.ino
@@ -3,7 +3,7 @@
 
   This sketch uses the ECC508 or ECC608 to sign some data
   using the private key of a key slot, the signature
-  is printed to the Serial monitor. Then the signature is
+  is printed to the Serial Monitor. Then the signature is
   verified using the public key of the slot.
 
   NOTE: the input data must be 64 bytes in length!
@@ -69,14 +69,14 @@ void setup() {
 
   Serial.println();
 
-  // To make the signature verifcation fail, uncomment the next line:
+  // To make the signature verification fail, uncomment the next line:
   //  signature[0] = 0x00;
 
   // validate the signature
   if (ECCX08.ecdsaVerify(input, signature, publicKey)) {
     Serial.println("Verified signature successfully :D");
   } else {
-    Serial.println("oh no! failed to verify signature :(");
+    Serial.println("Oh no! Failed to verify signature :(");
   }
 }
 

--- a/examples/Tools/ECCX08SelfSignedCert/ECCX08SelfSignedCert.ino
+++ b/examples/Tools/ECCX08SelfSignedCert/ECCX08SelfSignedCert.ino
@@ -4,7 +4,7 @@
   This sketch can be used to generate a self signed certificate
   for a private key generated in an ECC508/ECC608 crypto chip slot.
   The issue and expired date, and signature are stored in another
-  slot for reconstrution.
+  slot for reconstruction.
 
   If the ECC508/ECC608 is not configured and locked it prompts
   the user to configure and lock the chip with a default TLS

--- a/src/ECCX08.cpp
+++ b/src/ECCX08.cpp
@@ -62,7 +62,7 @@ int ECCX08Class::begin()
 
 void ECCX08Class::end()
 {
-  // First wake up the device otherwise the chip didn't react to a sleep commando
+  // First wake up the device otherwise the chip didn't react to a sleep command
   wakeup();
   sleep();
 #ifdef WIRE_HAS_END
@@ -627,7 +627,7 @@ int ECCX08Class::challenge(const byte message[])
     return 0;
   }
 
-  // Nounce, pass through
+  // Nonce, pass through
   if (!sendCommand(0x16, 0x03, 0x0000, message, 32)) {
     return 0;
   }
@@ -807,7 +807,7 @@ int ECCX08Class::addressForSlotOffset(int slot, int offset)
 
 int ECCX08Class::sendCommand(uint8_t opcode, uint8_t param1, uint16_t param2, const byte data[], size_t dataLength)
 {
-  int commandLength = 8 + dataLength; // 1 for type, 1 for length, 1 for opcode, 1 for param1, 2 for param2, 2 for crc
+  int commandLength = 8 + dataLength; // 1 for type, 1 for length, 1 for opcode, 1 for param1, 2 for param2, 2 for CRC
   byte command[commandLength]; 
   
   command[0] = 0x03;


### PR DESCRIPTION
A typo was introduced in a sketch comment via a recent PR merge. This caused the runs of the "Spell Check" GitHub Actions workflow to start failing:

https://github.com/arduino-libraries/ArduinoECCX08/actions/runs/4029882745

> [spellcheck: examples/ECCX08Signing/ECCX08Signing.ino#L72](https://github.com/arduino-libraries/ArduinoECCX08/commit/022ac98dcd966d838bc66460e660e6fb4ce8786d#annotation_8353736478)
verifcation ==> verification

The CI system did not identify the problem when validating the PR (https://github.com/arduino-libraries/ArduinoECCX08/pull/19) because at the time it was submitted the repository did not have a CI system (https://github.com/arduino-libraries/ArduinoECCX08/issues/28).

While I was at it, I did a comprehensive manual review of all repository content and fixed the other typos I found as well as the one detected by the automated spell check system.