### PR TITLE
Add library build configuration file

### DIFF
--- a/src/utility/ASN1Utils.cpp
+++ b/src/utility/ASN1Utils.cpp
@@ -410,4 +410,7 @@ int ASN1UtilsClass::appendEcdsaWithSHA256(byte out[])
   return 12;
 }
 
+#include "ECCX08UtilsConfig.h"
+#if defined(ECCX08_ENABLE_ASN1)
 ASN1UtilsClass ASN1Utils;
+#endif

--- a/src/utility/ECCX08CSR.cpp
+++ b/src/utility/ECCX08CSR.cpp
@@ -173,5 +173,7 @@ void ECCX08CSRClass::setCommonName(const char* commonName)
   _commonName = commonName;
 }
 
-
+#include "ECCX08UtilsConfig.h"
+#if defined(ECCX08_ENABLE_CSR)
 ECCX08CSRClass ECCX08CSR;
+#endif

--- a/src/utility/ECCX08JWS.cpp
+++ b/src/utility/ECCX08JWS.cpp
@@ -160,4 +160,7 @@ String ECCX08JWSClass::sign(int slot, const String& header, const String& payloa
   return sign(slot, header.c_str(), payload.c_str());
 }
 
+#include "ECCX08UtilsConfig.h"
+#if defined(ECCX08_ENABLE_JWS)
 ECCX08JWSClass ECCX08JWS;
+#endif

--- a/src/utility/ECCX08SelfSignedCert.cpp
+++ b/src/utility/ECCX08SelfSignedCert.cpp
@@ -406,4 +406,7 @@ void ECCX08SelfSignedCertClass::appendCertInfo(uint8_t publicKey[], uint8_t buff
   *out++ = 0x00;
 }
 
+#include "ECCX08UtilsConfig.h"
+#if defined(ECCX08_ENABLE_SSC)
 ECCX08SelfSignedCertClass ECCX08SelfSignedCert;
+#endif

--- a/src/utility/ECCX08UtilsConfig.h
+++ b/src/utility/ECCX08UtilsConfig.h
@@ -1,0 +1,39 @@
+/*
+  This file is part of the ArduinoECCX08 library.
+  Copyright (c) 2023 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _ECCX08_UTILS_CONFIG_H_
+#define _ECCX08_UTILS_CONFIG_H_
+
+#if defined __has_include
+  #if !__has_include ("ArduinoIoTCloud.h")
+    #define ECCX08_ENABLE_ASN1 1
+    #define ECCX08_ENABLE_CSR  1
+    #define ECCX08_ENABLE_JWS  1
+    #define ECCX08_ENABLE_SSC  1
+    #define ECCX08_ENABLE_PEM  1
+  #endif
+#else
+  #define ECCX08_ENABLE_ASN1 1
+  #define ECCX08_ENABLE_CSR  1
+  #define ECCX08_ENABLE_JWS  1
+  #define ECCX08_ENABLE_SSC  1
+  #define ECCX08_ENABLE_PEM  1
+#endif
+
+#endif

--- a/src/utility/PEMUtils.cpp
+++ b/src/utility/PEMUtils.cpp
@@ -68,4 +68,7 @@ String PEMUtilsClass::base64Encode(const byte in[], unsigned int length, const c
   return out;
 }
 
+#include "ECCX08UtilsConfig.h"
+#if defined(ECCX08_ENABLE_PEM)
 PEMUtilsClass PEMUtils;
+#endif


### PR DESCRIPTION
  ECCX08UtilsConfig.h file can be used  to include/exclude utility library objects from the build process.
  By default all the utilities are built unless ArduinoIoTCloud.h file is included