### PR TITLE
Build configuration: use a more flexible and already used pattern

### DIFF
--- a/src/ECCX08Config.h
+++ b/src/ECCX08Config.h
@@ -17,23 +17,13 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef _ECCX08_UTILS_CONFIG_H_
-#define _ECCX08_UTILS_CONFIG_H_
+#ifndef _ECCX08_CONFIG_H_
+#define _ECCX08_CONFIG_H_
 
 #if defined __has_include
-  #if !__has_include ("ArduinoIoTCloud.h")
-    #define ECCX08_ENABLE_ASN1 1
-    #define ECCX08_ENABLE_CSR  1
-    #define ECCX08_ENABLE_JWS  1
-    #define ECCX08_ENABLE_SSC  1
-    #define ECCX08_ENABLE_PEM  1
+  #if __has_include (<ArduinoECCX08Config.h>)
+    #include <ArduinoECCX08Config.h>
   #endif
-#else
-  #define ECCX08_ENABLE_ASN1 1
-  #define ECCX08_ENABLE_CSR  1
-  #define ECCX08_ENABLE_JWS  1
-  #define ECCX08_ENABLE_SSC  1
-  #define ECCX08_ENABLE_PEM  1
 #endif
 
 #endif

--- a/src/utility/ASN1Utils.cpp
+++ b/src/utility/ASN1Utils.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include "ECCX08Config.h"
 #include "ASN1Utils.h"
 
 int ASN1UtilsClass::versionLength()
@@ -410,7 +411,6 @@ int ASN1UtilsClass::appendEcdsaWithSHA256(byte out[])
   return 12;
 }
 
-#include "ECCX08UtilsConfig.h"
-#if defined(ECCX08_ENABLE_ASN1)
+#if !defined(ECCX08_DISABLE_ASN1)
 ASN1UtilsClass ASN1Utils;
 #endif

--- a/src/utility/ECCX08CSR.cpp
+++ b/src/utility/ECCX08CSR.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include "ECCX08Config.h"
 #include "ArduinoECCX08.h"
 
 #include "ASN1Utils.h"
@@ -173,7 +174,6 @@ void ECCX08CSRClass::setCommonName(const char* commonName)
   _commonName = commonName;
 }
 
-#include "ECCX08UtilsConfig.h"
-#if defined(ECCX08_ENABLE_CSR)
+#if !defined(ECCX08_DISABLE_CSR)
 ECCX08CSRClass ECCX08CSR;
 #endif

--- a/src/utility/ECCX08JWS.cpp
+++ b/src/utility/ECCX08JWS.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include "ECCX08Config.h"
 #include "ECCX08.h"
 
 #include "ASN1Utils.h"
@@ -160,7 +161,6 @@ String ECCX08JWSClass::sign(int slot, const String& header, const String& payloa
   return sign(slot, header.c_str(), payload.c_str());
 }
 
-#include "ECCX08UtilsConfig.h"
-#if defined(ECCX08_ENABLE_JWS)
+#if !defined(ECCX08_DISABLE_JWS)
 ECCX08JWSClass ECCX08JWS;
 #endif

--- a/src/utility/ECCX08SelfSignedCert.cpp
+++ b/src/utility/ECCX08SelfSignedCert.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include "ECCX08Config.h"
 #include "ArduinoECCX08.h"
 
 extern "C" {
@@ -406,7 +407,6 @@ void ECCX08SelfSignedCertClass::appendCertInfo(uint8_t publicKey[], uint8_t buff
   *out++ = 0x00;
 }
 
-#include "ECCX08UtilsConfig.h"
-#if defined(ECCX08_ENABLE_SSC)
+#if !defined(ECCX08_DISABLE_SSC)
 ECCX08SelfSignedCertClass ECCX08SelfSignedCert;
 #endif

--- a/src/utility/PEMUtils.cpp
+++ b/src/utility/PEMUtils.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include "ECCX08Config.h"
 #include "PEMUtils.h"
 
 String PEMUtilsClass::base64Encode(const byte in[], unsigned int length, const char* prefix, const char* suffix)
@@ -68,7 +69,6 @@ String PEMUtilsClass::base64Encode(const byte in[], unsigned int length, const c
   return out;
 }
 
-#include "ECCX08UtilsConfig.h"
-#if defined(ECCX08_ENABLE_PEM)
+#if !defined(ECCX08_DISABLE_PEM)
 PEMUtilsClass PEMUtils;
 #endif


### PR DESCRIPTION
After seeing [this](https://github.com/arduino-libraries/ArduinoBearSSL/blob/e9d5de59af852d18c8d8c0f925555da406da69f9/src/ArduinoBearSSL.h#L28) i think is much more flexible and i should have used the same pattern.