### PR TITLE
Fix regression re report-size-deltas after updating actions/upload-artifact.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -33,18 +33,31 @@ jobs:
       matrix:
         board:
           - fqbn: arduino:mbed:envie_m7
+            artifact-name-suffix: arduino-mbed-envie_m7
           - fqbn: arduino:megaavr:uno2018
+            artifact-name-suffix: arduino-megaavr-uno2018
           - fqbn: arduino:samd:mkr1000
+            artifact-name-suffix: arduino-samd-mkr1000
           - fqbn: arduino:samd:mkrwifi1010
+            artifact-name-suffix: arduino-samd-mkrwifi1010
           - fqbn: arduino:samd:nano_33_iot
+            artifact-name-suffix: arduino-samd-nano_33_iot
           - fqbn: arduino:samd:mkrwan1300
+            artifact-name-suffix: arduino-samd-mkr1300
           - fqbn: arduino:samd:mkrwan1310
+            artifact-name-suffix: arduino-samd-mkrwan1310
           - fqbn: arduino:samd:mkrgsm1400
+            artifact-name-suffix: arduino-samd-mkrgsm1400
           - fqbn: arduino:samd:mkrnb1500
+            artifact-name-suffix: arduino-samd-mkrnb1500
           - fqbn: arduino:samd:mkrvidor4000
+            artifact-name-suffix: arduino-samd-mkrvidor4000
           - fqbn: arduino:mbed_nano:nanorp2040connect
+            artifact-name-suffix: arduino-mbed_nano-nanorp2040connect
           - fqbn: arduino:mbed_opta:opta
+            artifact-name-suffix: arduino-mbed_opta-opta
           - fqbn: arduino:mbed_giga:giga
+            artifact-name-suffix: arduino-mbed_giga-giga
 
     steps:
       - name: Checkout
@@ -68,5 +81,5 @@ jobs:
       - name: Save memory usage change report as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}


### PR DESCRIPTION
For more information see https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .