### PR TITLE
ensure device goes into idle even on error

### DIFF
--- a/src/ECCX08.cpp
+++ b/src/ECCX08.cpp
@@ -173,48 +173,47 @@ int ECCX08Class::random(byte data[], size_t length)
 
 int ECCX08Class::generatePrivateKey(int slot, byte publicKey[])
 {
+  int result = 0;
+  
   if (!wakeup()) {
     return 0;
   }
 
-  if (!sendCommand(0x40, 0x04, slot)) {
-    return 0;
+  if (sendCommand(0x40, 0x04, slot)) {
+    delay(115);
+
+    if (receiveResponse(publicKey, 64)) {
+      delay(1);
+      result = 1;
+    }
   }
-
-  delay(115);
-
-  if (!receiveResponse(publicKey, 64)) {
-    return 0;
-  }
-
-  delay(1);
 
   idle();
-
-  return 1;
+  return result;
 }
 
 int ECCX08Class::generatePublicKey(int slot, byte publicKey[])
 {
-  if (!wakeup()) {
+  int result = 0;
+  
+  if (!wakeup())
+  {
     return 0;
   }
 
-  if (!sendCommand(0x40, 0x00, slot)) {
-    return 0;
+  if (sendCommand(0x40, 0x00, slot))
+  {
+    delay(115);
+
+    if (receiveResponse(publicKey, 64))
+    {
+      delay(1);
+      result = 1;
+    }
   }
-
-  delay(115);
-
-  if (!receiveResponse(publicKey, 64)) {
-    return 0;
-  }
-
-  delay(1);
 
   idle();
-
-  return 1;
+  return result;
 }
 
 int ECCX08Class::ecdsaVerify(const byte message[], const byte signature[], const byte pubkey[])


### PR DESCRIPTION
When working with keys, the device is not put properly to sleep if there is an error (for example the key does not exist when reading it). This makes subsequent commands also fail.

For example if i have a key in slot 2 but not 1.
```
  printPublicKeyForSlot(1);
  printPublicKeyForSlot(2);
```
will not print any key.
while   
```
printPublicKeyForSlot(2);
printPublicKeyForSlot(1);
```

will print the key for slot 2
