### PR TITLE
In case of error clear the wire buffer and put in idle mode

### DIFF
--- a/src/ECCX08.cpp
+++ b/src/ECCX08.cpp
@@ -915,6 +915,12 @@ int ECCX08Class::receiveResponse(void* response, size_t length)
 
   // make sure length matches
   if (responseBuffer[0] != responseSize) {
+    // Clear the buffer
+    for (size_t i = 1; _wire->available(); i++) {
+      (void) _wire->read();
+    }
+    delay(1);
+    idle();
     return 0;
   }
 
@@ -925,9 +931,11 @@ int ECCX08Class::receiveResponse(void* response, size_t length)
   // verify CRC
   uint16_t responseCrc = responseBuffer[length + 1] | (responseBuffer[length + 2] << 8);
   if (responseCrc != crc16(responseBuffer, responseSize - 2)) {
+    delay(1);
+    idle();
     return 0;
   }
-  
+
   memcpy(response, &responseBuffer[1], length);
 
   return 1;


### PR DESCRIPTION
### Problem
This PR addresses the problem that if any action fails, every other requests that might be completed successfully fail because the Wire data buffer is not cleared and the ECCX08 is not put into `idle` mode.

This PR covers also the problem highlighted in #70 

### How to reproduce the problem
Run this sketch changing the `slotID` with one that is empty:
```
#include <Arduino_SecureElement.h>
#include <utility/SElementArduinoCloudDeviceId.h>
#include <utility/SElementArduinoCloudCertificate.h>
#include <utility/SElementArduinoCloudJWT.h>
SecureElement secureElement;
int slotID = 4;

void setup() {
  // put your setup code here, to run once:
  Serial.begin(9600);
  while(!Serial);
    // Init the secure element
  if(!secureElement.begin()) {
    Serial.println("not begin");
    while(1);
  }

  if (!secureElement.locked()) {
    if (!secureElement.writeConfiguration()) {
          Serial.println("not write config");
    while(1);
    }

    if (!secureElement.lock()) {
                Serial.println("not locked");
    while(1);
    }
  }
  byte publicKey[64];
 
  if(!secureElement.generatePublicKey(slotID, publicKey)){
    
    Serial.println("slot 4 empty");
    if(!secureElement.generatePrivateKey(slotID, publicKey)){
      Serial.println("Error: private key generation failed");
    }else{
      Serial.println("generation prvk completed");
      for(uint8_t i=0; i<sizeof(publicKey); i++){
        Serial.print(publicKey[i], HEX);
        Serial.print(" ");
      }
    
    }
  } else{
    Serial.println("slot 4 not empty");
  }
}

void loop() {
  // put your main code here, to run repeatedly:

}
```
The expected output is:
```
slot 4 empty
generation prvk completed
[the public key]
```
The current output:
```
slot 4 empty
Error: private key generation failed
```