### PR TITLE
Initial zephyr support

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -58,6 +58,15 @@ jobs:
             artifact-name-suffix: arduino-mbed_opta-opta
           - fqbn: arduino:mbed_giga:giga
             artifact-name-suffix: arduino-mbed_giga-giga
+          - fqbn: "arduino:zephyr_main:portentah7"
+            platform-name: arduino:zephyr_main
+            artifact-name-suffix: arduino-zephyr_main-portentah7
+          - fqbn: "arduino:zephyr_main:giga"
+            platform-name: arduino:zephyr_main
+            artifact-name-suffix: arduino-zephyr_main-giga
+          - fqbn: "arduino:zephyr_main:opta"
+            platform-name: arduino:zephyr_main
+            artifact-name-suffix: arduino-zephyr_main-opta
 
     steps:
       - name: Checkout

--- a/src/ECCX08.cpp
+++ b/src/ECCX08.cpp
@@ -24,6 +24,9 @@
 const uint32_t ECCX08Class::_wakeupFrequency = 100000u;  // 100 kHz
 #ifdef __AVR__
 const uint32_t ECCX08Class::_normalFrequency = 400000u;  // 400 kHz
+#elif defined(ARDUINO_ARCH_ZEPHYR) && defined(ARDUINO_PORTENTA_H7_M7)
+// FIXME speed above 400kHz require manual configuration in stm32 running on zephyr
+const uint32_t ECCX08Class::_normalFrequency = 400000u;
 #else
 const uint32_t ECCX08Class::_normalFrequency = 1000000u; // 1 MHz
 #endif
@@ -969,6 +972,12 @@ uint16_t ECCX08Class::crc16(const byte data[], size_t length)
 
   return crc;
 }
+
+#if __ZEPHYR__
+  #ifndef CRYPTO_WIRE
+    #define CRYPTO_WIRE Wire1
+  #endif
+#endif
 
 #ifdef CRYPTO_WIRE
 ECCX08Class ECCX08(CRYPTO_WIRE, 0x60);


### PR DESCRIPTION
Note: in order to avoid error messages and possible faults i2c frequency is reduced during normal communication to 400kHz, in  order to reach higher frequency timings needs to be configured on zephyr dts files.